### PR TITLE
Add ability to use custom VSTS account based on organization/requester

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,16 @@
       "required": true
     },
     {
+      "name": "org_field_vso_account",
+      "type": "text",
+      "required": false
+    },
+    {
+      "name": "user_field_vso_account",
+      "type": "text",
+      "required": false
+    },
+    {
       "name": "vso_tag",
       "type": "text",
       "required": false,

--- a/templates/login.hdbs
+++ b/templates/login.hdbs
@@ -3,6 +3,7 @@
         <i class='icon-circle-arrow-left'/>
     </a>
     <h3>{{t "login.title"}}</h3>
+    <div class='help'>{{vso_account}}</div>
     <div class='content'>
         <p>&nbsp;</p>
         <p class="help">{{t "login.help"}}</p>

--- a/translations/en.json
+++ b/translations/en.json
@@ -2,8 +2,16 @@
   "app": {
     "parameters": {
       "vso_account": {
-        "label": "Visual Studio Team Services account name",
-        "helpText": "Enter your Visual Studio Team Services subdomain (part before visualstudio.com). Learn more by visiting http://go.microsoft.com/fwlink/?LinkID=396756"
+        "label": "Global Visual Studio Team Services account name",
+        "helpText": "Enter your default Visual Studio Team Services subdomain (part before visualstudio.com). Learn more by visiting http://go.microsoft.com/fwlink/?LinkID=396756"
+      },
+      "org_field_vso_account": {
+        "label": "Organization Field indicating Visual Studio Team Services account",
+        "helpText": "You override VSTS account for each organization."
+      },
+      "user_field_vso_account": {
+        "label": "User Field indicating Visual Studio Team Services account",
+        "helpText": "You can override VSTS account for each user."
       },
       "vso_tag": {
         "label": "Visual Studio Team Services work item tag",


### PR DESCRIPTION
In our organization we have different VSTS accounts for each customer. I customized this plugin to allow users to override VSTS url based on organization and/or requester.
Basically we'll need a custom field in organization/user to indicate the VSTS account.