### PR TITLE
Fix for issue #4 - load all VSTS projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This PR fixes issue #4 by loading all the VSTS projects for a given accounts.

We fetch 100 projects each time we hit VSTS - if the returned result has 100 project, we try to fetch more by skipping the previous projects.