### PR TITLE
Support to Pt-br | Severity fix | new app Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Unite your customer support and development teams. Quickly create or link work i
 ### Create work items for your engineers right from Zendesk
 
 With the Visual Studio Team Services app for Zendesk, users in Zendesk can quickly create a new work item from a Zendesk ticket.
+
 ![img](https://i3-vso.sec.s-msft.com/dynimg/IC729561.png)
 
 ### Get instant access to the status of linked work items
 
-Give your customer support team easy access to the information they need. See details about work items linked to a Zendesk ticket, including curr
+Give your customer support team easy access to the information they need. See details about work items linked to a Zendesk ticket.
 
 ![img](https://ms-vsts.gallery.vsassets.io/_apis/public/gallery/publisher/ms-vsts/extension/services-zendesk/latest/assetbyname/images/zendesk-linked.png)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Visual Studio Team Services App for Zendesk
 
-> Get the latest version of the app: [Download v0.4.1](https://github.com/Microsoft/vsts-zendesk-app/releases/download/v0.4.1/apps-vsts-zendesk-app_0.4.1.zip)
+> Get the latest version of the app: [Download v0.4.2](https://github.com/Microsoft/vsts-zendesk-app/releases/download/v0.4.2/vsts-zendesk-app-0.4.2.zip)
 
 Unite your customer support and development teams. Quickly create or link work items to tickets, enable efficient two-way communication, and stop using email to check status.
 
 ### Create work items for your engineers right from Zendesk
 
 With the Visual Studio Team Services app for Zendesk, users in Zendesk can quickly create a new work item from a Zendesk ticket.
-
 ![img](https://i3-vso.sec.s-msft.com/dynimg/IC729561.png)
 
 ### Get instant access to the status of linked work items
@@ -20,7 +19,7 @@ Give your customer support team easy access to the information they need. See de
 
 ### Install the app to Zendesk
 
-1. Download the latest release .zip file: **[version 0.4.1](https://github.com/Microsoft/vsts-zendesk-app/releases/download/v0.4.1/apps-vsts-zendesk-app_0.4.1.zip)**
+1. Download the latest release .zip file: **[version 0.4.2](https://github.com/Microsoft/vsts-zendesk-app/releases/download/v0.4.2/vsts-zendesk-app-0.4.2.zip)**
 1. From Zendesk, click the settings icon (gear)
 1. Under **Apps** click Manage.
 1. Click **Upload private app**

--- a/app.js
+++ b/app.js
@@ -428,8 +428,8 @@
         operations.push(this.buildPatchToAddWorkItemField("System.AreaId", areaId));
       }
 
-      if (this.hasFieldDefined(workItemType, "Microsoft.VSTS.Common.Severity") && $modal.find('.severity').val()) {
-        operations.push(this.buildPatchToAddWorkItemField("Microsoft.VSTS.Common.Severity", $modal.find('.severity').val()));
+      if (this.hasFieldDefined(workItemType, "Microsoft.VSTS.Common.Severity") && $modal.find('#severity').val()) {
+        operations.push(this.buildPatchToAddWorkItemField("Microsoft.VSTS.Common.Severity", $modal.find('#severity').val()));
       }
 
       if (this.hasFieldDefined(workItemType, "Microsoft.VSTS.TCM.ReproSteps")) {

--- a/app.js
+++ b/app.js
@@ -26,8 +26,7 @@
       }),
       VSO_ZENDESK_LINK_TO_TICKET_PREFIX = "ZendeskLinkTo_Ticket_",
       VSO_ZENDESK_LINK_TO_TICKET_ATTACHMENT_PREFIX = "ZendeskLinkTo_Attachment_Ticket_",
-      //VSO_WI_TYPES_WHITE_LISTS = ["Bug", "Product Backlog Item", "User Story", "Requirement", "Issue"],
-      VSO_WI_TYPES_WHITE_LISTS = ["Bug", "Product Backlog Item", "User Story", "Requirement"],      
+
       VSO_PROJECTS_PAGE_SIZE = 100;
 
   //#endregion
@@ -1095,7 +1094,12 @@
     },
 
     restrictToAllowedWorkItems: function (wits) {
-      return _.filter(wits, function (wit) { return _.contains(VSO_WI_TYPES_WHITE_LISTS, wit.name); });
+        var allowed_workitems = this.setting('allowed_workitems').split(',').map(function(s) { 
+                    return s.trim();
+                });
+                
+        return _.filter(wits, function (wit) { 
+            return _.contains(allowed_workitems, wit.name); });
     },
 
     buildPatchToAddWorkItemField: function (fieldName, value) {

--- a/app.js
+++ b/app.js
@@ -426,9 +426,6 @@
 
       if (areaId) {
         operations.push(this.buildPatchToAddWorkItemField("System.AreaId", areaId));
-
-      if (this.hasFieldDefined(workItemType, "Microsoft.VSTS.Common.Severity") && $modal.find('#severity').val()) {
-        operations.push(this.buildPatchToAddWorkItemField("Microsoft.VSTS.Common.Severity", $modal.find('#severity').val()));
       }
 
       if (this.hasFieldDefined(workItemType, "Microsoft.VSTS.Common.Severity") && $modal.find('#severity').val()) {

--- a/app.js
+++ b/app.js
@@ -426,6 +426,9 @@
 
       if (areaId) {
         operations.push(this.buildPatchToAddWorkItemField("System.AreaId", areaId));
+
+      if (this.hasFieldDefined(workItemType, "Microsoft.VSTS.Common.Severity") && $modal.find('#severity').val()) {
+        operations.push(this.buildPatchToAddWorkItemField("Microsoft.VSTS.Common.Severity", $modal.find('#severity').val()));
       }
 
       if (this.hasFieldDefined(workItemType, "Microsoft.VSTS.Common.Severity") && $modal.find('#severity').val()) {

--- a/app.js
+++ b/app.js
@@ -1059,12 +1059,15 @@
       
       var loadAreas = this.ajax('getVsoProjectAreas', project.id).done(function (rootArea) {
         var areas = [];
+        var allowedArea = this.setting('allowed_rootAreaPath');
         // Flatten areas to format \Area 1\Area 1.1
         var visitArea = function (area, currentPath) {
           currentPath = currentPath ? currentPath + "\\" : "";
           currentPath = currentPath + area.name;
-          areas.push({ id: area.id, name: currentPath });
           
+          if (!allowedArea || currentPath.indexOf(allowedArea) === 0)
+            areas.push({ id: area.id, name: currentPath });
+
           if (area.children && area.children.length > 0) {
             _.forEach(area.children, function (child) { visitArea(child, currentPath); });
           }

--- a/app.js
+++ b/app.js
@@ -26,7 +26,8 @@
       }),
       VSO_ZENDESK_LINK_TO_TICKET_PREFIX = "ZendeskLinkTo_Ticket_",
       VSO_ZENDESK_LINK_TO_TICKET_ATTACHMENT_PREFIX = "ZendeskLinkTo_Attachment_Ticket_",
-      VSO_WI_TYPES_WHITE_LISTS = ["Bug", "Product Backlog Item", "User Story", "Requirement", "Issue"],
+      //VSO_WI_TYPES_WHITE_LISTS = ["Bug", "Product Backlog Item", "User Story", "Requirement", "Issue"],
+      VSO_WI_TYPES_WHITE_LISTS = ["Bug", "Product Backlog Item", "User Story", "Requirement"],      
       VSO_PROJECTS_PAGE_SIZE = 100;
 
   //#endregion

--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,11 @@
       "type": "text",
       "required": true,
       "default": "Bug, Product Backlog Item, User Story, Requirement, Issue"  
+    },
+    {
+      "name": "allowed_rootAreaPath",
+      "type": "text",
+      "required": false
     },  
     {
       "name": "vso_field_settings",

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   "singleInstall": true,
   "private": true,
   "frameworkVersion": "1.0",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "parameters": [
     {
       "name": "vso_account",

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,12 @@
       "type": "text",
       "required": false,
       "default": "zendesk"
+    },
+    {
+      "name": "allowed_workitems",
+      "type": "text",
+      "required": true,
+      "default": "Bug, Product Backlog Item, User Story, Requirement, Issue"  
     },  
     {
       "name": "vso_field_settings",

--- a/templates/new.hdbs
+++ b/templates/new.hdbs
@@ -31,10 +31,10 @@
             <label class='control-label' for='severity'>{{t "modals.new.fields.severity"}}</label>
             <div class='controls'>
                 <select id='severity' class='input-xlarge'>
-                    <option value='4 - Low'>1 - {{t "modals.new.severity.low"}}</option>
-                    <option value='3 - Medium'>2 - {{t "modals.new.severity.medium"}}</option>
-                    <option value='2 - High'>3 - {{t "modals.new.severity.high"}}</option>
-                    <option value='1 - Critical'>4 - {{t "modals.new.severity.critical"}}</option>
+                    <option value='4 - Low'>{{t "modals.new.severity.low"}}</option>
+                    <option value='3 - Medium'>{{t "modals.new.severity.medium"}}</option>
+                    <option value='2 - High'>{{t "modals.new.severity.high"}}</option>
+                    <option value='1 - Critical'>{{t "modals.new.severity.critical"}}</option>
                 </select>
             </div>
         </div>

--- a/templates/new.hdbs
+++ b/templates/new.hdbs
@@ -31,10 +31,10 @@
             <label class='control-label' for='severity'>{{t "modals.new.fields.severity"}}</label>
             <div class='controls'>
                 <select id='severity' class='input-xlarge'>
-                    <option value='4 - Low'>1 - Low</option>
-                    <option value='3 - Medium'>2 - Medium</option>
-                    <option value='2 - High'>3 - High</option>
-                    <option value='1 - Critical'>4 - Critical</option>
+                    <option value='4 - Low'>1 - {{t "modals.new.severity.low"}}</option>
+                    <option value='3 - Medium'>2 - {{t "modals.new.severity.medium"}}</option>
+                    <option value='2 - High'>3 - {{t "modals.new.severity.high"}}</option>
+                    <option value='1 - Critical'>4 - {{t "modals.new.severity.critical"}}</option>
                 </select>
             </div>
         </div>

--- a/templates/new.hdbs
+++ b/templates/new.hdbs
@@ -31,10 +31,10 @@
             <label class='control-label' for='severity'>{{t "modals.new.fields.severity"}}</label>
             <div class='controls'>
                 <select id='severity' class='input-xlarge'>
-                    <option value='1 - Critical'>1 - Critical</option>
-                    <option value='2 - High'>2 - High</option>
-                    <option value='3 - Medium'>3 - Medium</option>
-                    <option value='4 - Low'>4 - Low</option>
+                    <option value='4 - Low'>1 - Low</option>
+                    <option value='3 - Medium'>2 - Medium</option>
+                    <option value='2 - High'>3 - High</option>
+                    <option value='1 - Critical'>4 - Critical</option>
                 </select>
             </div>
         </div>

--- a/translations/en.json
+++ b/translations/en.json
@@ -98,10 +98,10 @@
             },
             "copyDescription": "Copy the ticket's description",
             "severity": {
-                "critical": "Critical",
-                "high": "High",
-                "medium": "Medium",
-                "low": "Low"
+                "critical": "1- Critical",
+                "high": "2- High",
+                "medium": "3- Medium",
+                "low": "4- Low"
             }
         },
         "notify": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -8,6 +8,10 @@
             "vso_tag": {
                 "label": "Visual Studio Team Services work item tag",
                 "helpText": "Enter the tag you want to add to each Visual Studio Team Services linked work item. If empty, no tag will be added."
+            },
+            "allowed_workitems": {
+                "label": "Visual Studio Team Services work items types allowed",
+                "helpText": "Enter work items types allowed to be created by Zendesk"
             }
         }
     },

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,126 +1,133 @@
 {
-  "app": {
-    "parameters": {
-      "vso_account": {
-        "label": "Visual Studio Team Services account name",
-        "helpText": "Enter your Visual Studio Team Services subdomain (part before visualstudio.com). Learn more by visiting http://go.microsoft.com/fwlink/?LinkID=396756"
-      },
-      "vso_tag": {
-        "label": "Visual Studio Team Services work item tag",
-        "helpText": "Enter the tag you want to add to each Visual Studio Team Services linked work item. If empty, no tag will be added."
-      }
-    }
-  },
-  "buttons": {
-    "create": "New work item",
-    "link": "Link to work item",
-    "notify": "Notify"
-  },
-  "parts": {
-    "workItems": "Linked work items"
-  },
-  "admin": {
-    "title": "Administration",
-    "summary": "Summary",
-    "details": "Details",
-    "settingsSaved": "Your Visual Studio Team Services settings have been saved."
-  },
-  "login": {
-    "title": "Login",
-    "help": "Set your Visual Studio Team Services alternate credentials.",
-    "username": "Username",
-    "password": "Password",
-    "button": "Login",
-    "errRequiredFields": "Both username and password fields are required"
-  },
-  "workItems": {
-    "unlink": "Unlink this work item",
-    "showDetails": "Show more details about this work item",
-    "noWorkItem": "There are no work items related to this ticket.",
-    "title": "Linked work items ({{count}})"
-  },
-  "queryResults": {
-    "columnId": "Id",
-    "columnType": "Type",
-    "columnTitle": "Title",
-    "noWorkItem": "No work items returned by query.",
-    "returnedWorkItems": "Query returned {{count}} work items"
-  },
-  "modals": {
-    "details": {
-      "title": "{{name}} details",
-      "loading": "Loading work item details...",
-      "close": "Close"
+    "app": {
+        "parameters": {
+            "vso_account": {
+                "label": "Visual Studio Team Services account name",
+                "helpText": "Enter your Visual Studio Team Services subdomain (part before visualstudio.com). Learn more by visiting http://go.microsoft.com/fwlink/?LinkID=396756"
+            },
+            "vso_tag": {
+                "label": "Visual Studio Team Services work item tag",
+                "helpText": "Enter the tag you want to add to each Visual Studio Team Services linked work item. If empty, no tag will be added."
+            }
+        }
     },
-    "unlink": {
-      "title": "Unlink work item",
-      "text": "Are you sure you want to unlink <strong>{{name}}</strong> from this ticket?",
-      "close": "No, don't do anything",
-      "accept": "Yes, unlink it.",
-      "errUnlink": "Could not unlink ticket in Visual Studio Team Services. Please try again."
+    "buttons": {
+        "create": "New work item",
+        "link": "Link to work item",
+        "notify": "Notify"
     },
-    "link": {
-      "title": "Link to a work item",
-      "close": "Go back",
-      "accept": "Link",
-      "search": "Search",
-      "query": "Query",
-      "reloadQueries": "Reload queries list",
-      "help": "Please enter the the work item id you'd like to link this ticket with. If you don't know the number of the work item to link, click in button 'Search' to help you find out the work item.",
-      "searchLegend": "Search",
-      "projectLabel": "Project",
-      "queryLabel": "Query",
-      "errWorkItemIdNaN": "The work item id must be a number.",
-      "errCannotGetWorkItem": "Something went wrong while checking work item. Please try again.",
-      "errCannotUpdateWorkItem": "Something went wrong while updating work item. Please try again.",
-      "errAlreadyLinked": "This ticket is already linked that work item."
+    "parts": {
+        "workItems": "Linked work items"
     },
-    "new": {
-      "title": "New Visual Studio Team Services Work Item",
-      "close": "Go back",
-      "accept": "Create work item",
-      "help": "Fill this form to create a new Visual Studio Team Services work item and link it to this ticket.",
-      "automatic": "Automatic",
-      "errProjRequired": "The project is required",
-      "errWorkItemTypeRequired": "The work item type is required",
-      "errSummaryRequired": "The summary is required",
-      "fields": {
-        "project": "Project",
-        "area": "Area",
-        "type": "Type",
+    "admin": {
+        "title": "Administration",
         "summary": "Summary",
-        "description": "Description",
-        "assignee": "Assignee",
-        "requester": "Requester",
-        "attachments": "Attachments",
-        "severity": "Severity"
+        "details": "Details",
+        "settingsSaved": "Your Visual Studio Team Services settings have been saved."
       },
-      "copyDescription": "Copy the ticket's description"
+    "login": {
+        "title": "Login",
+        "help": "Set your Visual Studio Team Services alternate credentials.",
+        "username": "Username",
+        "password": "Password",
+        "button": "Login",
+        "errRequiredFields": "Both username and password fields are required"
+    },
+    "workItems": {
+        "unlink": "Unlink this work item",
+        "showDetails": "Show more details about this work item",
+        "noWorkItem": "There are no work items related to this ticket.",
+        "title": "Linked work items ({{count}})"
+    },
+    "queryResults": {
+        "columnId": "Id",
+        "columnType": "Type",
+        "columnTitle": "Title",
+        "noWorkItem": "No work items returned by query.",
+        "returnedWorkItems": "Query returned {{count}} work items"
+    },
+    "modals": {
+        "details": {
+            "title": "{{name}} details",
+            "loading": "Loading work item details...",
+            "close": "Close"
+        },
+        "unlink": {
+            "title": "Unlink work item",
+            "text": "Are you sure you want to unlink <strong>{{name}}</strong> from this ticket?",
+            "close": "No, don't do anything",
+            "accept": "Yes, unlink it.",
+            "errUnlink": "Could not unlink ticket in Visual Studio Team Services. Please try again."
+        },
+        "link": {
+            "title": "Link to a work item",
+            "close": "Go back",
+            "accept": "Link",
+            "search": "Search",
+            "query": "Query",
+            "reloadQueries": "Reload queries list",
+            "help": "Please enter the the work item id you'd like to link this ticket with. If you don't know the number of the work item to link, click in button 'Search' to help you find out the work item.",
+            "searchLegend": "Search",
+            "projectLabel": "Project",
+            "queryLabel": "Query",
+            "errWorkItemIdNaN": "The work item id must be a number.",
+            "errCannotGetWorkItem": "Something went wrong while checking work item. Please try again.",
+            "errCannotUpdateWorkItem": "Something went wrong while updating work item. Please try again.",
+            "errAlreadyLinked": "This ticket is already linked that work item."
+        },
+        "new": {
+            "title": "New Visual Studio Team Services Work Item",
+            "close": "Go back",
+            "accept": "Create work item",
+            "help": "Fill this form to create a new Visual Studio Team Services work item and link it to this ticket.",
+            "automatic": "Automatic",
+            "errProjRequired": "The project is required",
+            "errWorkItemTypeRequired": "The work item type is required",
+            "errSummaryRequired": "The summary is required",
+            "fields": {
+                "project": "Project",
+                "area": "Area",
+                "type": "Type",
+                "summary": "Summary",
+                "description": "Description",
+                "assignee": "Assignee",
+                "requester": "Requester",
+                "attachments": "Attachments",
+                "severity": "Severity",
+                "DevelopmentDate": "Development Date"
+            },
+            "copyDescription": "Copy the ticket's description",
+            "severity": {
+                "critical": "Critical",
+                "high": "High",
+                "medium": "Medium",
+                "low": "Low"
+            }
+        },
+        "notify": {
+            "title": "Notify linked work items",
+            "close": "Go back",
+            "accept": "Notify work items",
+            "placeholder": "Type in some text to add to the notification",
+            "copyLastComment": "Copy the last comment",
+            "errCommentRequired": "The notification is required"
+        }
     },
     "notify": {
-      "title": "Notify linked work items",
-      "close": "Go back",
-      "accept": "Notify work items",
-      "placeholder": "Type in some text to add to the notification",
-      "copyLastComment": "Copy the last comment",
-      "errCommentRequired": "The notification is required"
-    }
-  },
-  "notify": {
-    "message": "-- This notification was sent from Zendesk to all linked Visual Studio Team Services work items by {{name}}. --",
-    "vso": "Notification from Visual Studio Team Services work item {{workItemKey}}",
-    "notification": "The linked Visual Studio Team Services work items have been notified",
-    "workItemCreated": "Work item created in Visual Studio Team Services with id: %@",
-    "workItemLinked": "Ticket linked with Visual Studio Team Services work item with id: %@",
-    "workItemUnlinked": "Ticket unlinked of Visual Studio Team Services work item with id: %@",
-    "credentialsSaved": "Saved Successfully"
-  },
-  "finishSetup": "You didn't finish your app configuration: your Visual Studio Team Services account is empty.",
-  "errorAjax": "There was an error contacting with the server. Please try again",
-  "errorServer": "[%@ %@: %@]",
-  "errorLoadingApp": "Something went wrong while loading the app. Confirm that your Visual Studio Team Services alternate credentials are correct by clicking in the user icon.",
-  "errorInvalidAccount": "The Visual Studio Team Services account '{{accountName}}' doesn't exist or you don't have access to it. Contact your Zendesk account Administrator to check and review the app settings.",
-  "errorLoadingWorkItems": "Something went wrong while loading working items. Click the refresh icon to try again.",
-  "errorOoops": "Ooops!",
-  "errorReadingFieldSettings": "There was an error while reading field settings. Applying default settings."
+        "message": "-- This notification was sent from Zendesk to all linked Visual Studio Team Services work items by {{name}}. --",
+        "vso": "Notification from Visual Studio Team Services work item {{workItemKey}}",
+        "notification": "The linked Visual Studio Team Services work items have been notified",
+        "workItemCreated": "Work item created in Visual Studio Team Services with id: %@",
+        "workItemLinked": "Ticket linked with Visual Studio Team Services work item with id: %@",
+        "workItemUnlinked": "Ticket unlinked of Visual Studio Team Services work item with id: %@",
+        "credentialsSaved": "Saved Successfully"
+    },
+    "finishSetup": "You didn't finish your app configuration: your Visual Studio Team Services account is empty.",
+    "errorAjax": "There was an error contacting with the server. Please try again",
+    "errorServer": "[%@ %@: %@]",
+    "errorLoadingApp": "Something went wrong while loading the app. Confirm that your Visual Studio Team Services alternate credentials are correct by clicking in the user icon.",
+    "errorInvalidAccount": "The Visual Studio Team Services account '{{accountName}}' doesn't exist or you don't have access to it. Contact your Zendesk account Administrator to check and review the app settings.",
+    "errorLoadingWorkItems": "Something went wrong while loading working items. Click the refresh icon to try again.",
+    "errorOoops": "Ooops!",
+    "errorReadingFieldSettings": "There was an error while reading field settings. Applying default settings."
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -12,6 +12,10 @@
             "allowed_workitems": {
                 "label": "Visual Studio Team Services work items types allowed",
                 "helpText": "Enter work items types allowed to be created by Zendesk"
+            },
+            "allowed_rootAreaPath": {
+                "label": "Visual Studio Team Services work items area path",
+                "helpText": "Enter the root area path for work items"
             }
         }
     },

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1,0 +1,127 @@
+{
+  "app": {
+    "parameters": {
+      "vso_account": {
+        "label": "Visual Studio Team Services account name",
+        "helpText": "Enter your Visual Studio Team Services subdomain (part before visualstudio.com). Learn more by visiting http://go.microsoft.com/fwlink/?LinkID=396756"
+      },
+      "vso_tag": {
+        "label": "Visual Studio Team Services work item tag",
+        "helpText": "Enter the tag you want to add to each Visual Studio Team Services linked work item. If empty, no tag will be added."
+      }
+    }
+  },
+  "buttons": {
+    "create": "Novo work item",
+    "link": "Vincular a um work item",
+    "notify": "Notificar"
+  },
+  "parts": {
+    "workItems": "Work items vinculados"
+  },
+  "admin": {
+    "title": "Administration",
+    "summary": "Summary",
+    "details": "Details",
+    "settingsSaved": "Your Visual Studio Team Services settings have been saved."
+  },
+  "login": {
+    "title": "Login",
+    "help": "Defina suas credenciais alternativas Visual Studio Team Services.",
+    "username": "Usuário",
+    "password": "Senha",
+    "button": "Login",
+    "errRequiredFields": "Os campos Usuário e Senha são obrigatórios"
+  },
+  "workItems": {
+    "unlink": "Desvincular este item de trabalho",
+    "showDetails": "Mostrar mais detalhes deste item de trabalho",
+    "noWorkItem": "Não há itens de trabalho vinculados a este ticket.",
+    "title": "Itens de trabalho vinculados: {{count}}"
+  },
+  "queryResults": {
+    "columnId": "Id",
+    "columnType": "Tipo",
+    "columnTitle": "Título",
+    "noWorkItem": "A consulta não retornou nenhum item de trabalho.",
+    "returnedWorkItems": "A consulta retornou {{count}} itens de trabalho"
+  },
+  "modals": {
+    "details": {
+      "title": "{{name}} detalhes",
+      "loading": "Carregando detalhes do item de trabalho...",
+      "close": "Fechar"
+    },
+    "unlink": {
+      "title": "Desvincular item de trabalho",
+      "text": "Você deseja desvincular o item <strong>{{name}}</strong> deste ticket?",
+      "close": "Não, não faça nada",
+      "accept": "Sim, desvincule o item de trabalho.",
+      "errUnlink": "Não foi possível desvincular o ticket no Visual Studio Team Services. Por favor, tente novamente."
+    },
+    "link": {
+      "title": "Vincular a um item de trabalho existente",
+      "close": "Voltar",
+      "accept": "Vincular",
+      "search": "Buscar",
+      "query": "Query",
+      "reloadQueries": "Recarregar lista de consulta",
+      "help": "Entre o ID do item de trablho que você gostaria de vincular a este ticket. Se você não souber o Id do item de trabalho para vincular, clique no botão 'Procurar' para pesquisar o item de trabalho correspondente.", 
+      "searchLegend": "Procurar",
+      "projectLabel": "Projeto",
+      "queryLabel": "Consulta",
+      "errWorkItemIdNaN": "O Id do item de trabalho deve ser um número.",
+      "errCannotGetWorkItem": "Um erro aconteceu enquanto pesquisava o item de trabalho. Por favor, tente novamente.", 
+      "errCannotUpdateWorkItem": "Algo aconteceu enquanto atualizava o item de trabalho. Por favor, tente novamente.", 
+      "errAlreadyLinked": "Este ticket já esta vinculado a este item de trabalho."
+    },
+    "new": {
+      "title": "Novo item de trabalho de desenvolvimento",
+      "close": "Voltar",
+      "accept": "Criar Item de Trabalho de Desenvolvimento",
+      "help": "Preencha este formulário para criar um novo item de trabalho para desenvolvimento, vinculado a este ticket.", 
+      "automatic": "Automatic",
+      "errProjRequired": "O projeto é obrigatório",
+      "errWorkItemTypeRequired": "O tipo de work item é obrigatório",
+      "errSummaryRequired": "O título é obrigatório",
+      "fields": {
+        "project": "Projeto",
+        "area": "Area",
+        "type": "Tipo",
+        "summary": "Título",
+        "description": "Descrição",
+        "assignee": "Assignee",
+        "requester": "Requester",
+        "attachments": "Anexos",
+        "severity": "Criticidade",
+        "DevelopmentDate": "Data de desenvolvimento"
+      },
+      "copyDescription": "Copiar descrição do Ticket"
+    },
+    "notify": {
+      "title": "Novo comentário no item de trabalho",
+      "close": "Voltar",
+      "accept": "Comentar no item de trabalho",
+      "placeholder": "Digite o texto para comentar no item de trabalho",
+      "copyLastComment": "Copiar último comentário do Ticket",
+      "errCommentRequired": "O comentário é obrigatório"
+    }
+  },
+  "notify": {
+    "message": "-- Esta notificação será enviada pelo Zendesk para todos os itens de trabalho do Visual Studio Team Services vinculados por {{name}}. --", 
+    "vso": "Comentário do item de trabalho de desenvolvimento {{workItemKey}}", 
+    "notification": "O item de trabalho de desenvolvimento vinculados a este ticket foram notificados",
+    "workItemCreated": "Item de trabalho de desenvolvimento criado com o id: %@", 
+    "workItemLinked": "Ticket vinculado com o item de trabalho de desenvolvimento com id: %@", 
+    "workItemUnlinked": "Ticket desvinculado com o item de trabalho de desenvolvimento com id: %@",
+    "credentialsSaved": "Salvo com sucesso"
+  },
+  "finishSetup": "Você não finalizou a configuração da aplicação: A conta do VSTS esta vazia.", 
+  "errorAjax": "Houve um erro na chamada ao servidor. Por favor, tente novamente", 
+  "errorServer": "[%@ %@: %@]",
+  "errorLoadingApp": "Algo errado aconteceu enquanto carregava a aplicação. Confirme que o login e senha estão corretas clicando no ícone do usuário.",
+  "errorInvalidAccount": "A conta do VSTS '{{accountName}}' não existe ou você não tem permissão de acessá-la. Contate o adminitrador do Zendesk para verificar e rever as configurações do aplicativo.",
+  "errorLoadingWorkItems": "Algo errado ao carregar os itens de trabalho. Clique no ícone Recarregar para tentar novamente",
+  "errorOoops": "Ooops!",
+  "errorReadingFieldSettings": "Houve um erro ao ler as configurações. Aplicando as configurações padrão"
+}

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -98,10 +98,10 @@
             },
             "copyDescription": "Copiar descrição do Ticket",
             "severity": {
-                "critical": "Crítico",
-                "high": "Alto",
-                "medium": "Médio",
-                "low": "Baixo"
+                "critical": "1- Crítico",
+                "high": "2- Alto",
+                "medium": "3- Médio",
+                "low": "4- Baixo"
             }
         },
         "notify": {

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -12,6 +12,10 @@
             "allowed_workitems": {
                 "label": "Visual Studio Team Services work items types allowed",
                 "helpText": "Enter work items types allowed to be created by Zendesk"
+            },
+             "allowed_rootAreaPath": {
+                "label": "Visual Studio Team Services work items area path",
+                "helpText": "Enter the root area path for work items"
             }
         }
     },

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -8,6 +8,10 @@
             "vso_tag": {
                 "label": "Visual Studio Team Services work item tag",
                 "helpText": "Enter the tag you want to add to each Visual Studio Team Services linked work item. If empty, no tag will be added."
+            },
+            "allowed_workitems": {
+                "label": "Visual Studio Team Services work items types allowed",
+                "helpText": "Enter work items types allowed to be created by Zendesk"
             }
         }
     },

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1,127 +1,133 @@
 {
-  "app": {
-    "parameters": {
-      "vso_account": {
-        "label": "Visual Studio Team Services account name",
-        "helpText": "Enter your Visual Studio Team Services subdomain (part before visualstudio.com). Learn more by visiting http://go.microsoft.com/fwlink/?LinkID=396756"
-      },
-      "vso_tag": {
-        "label": "Visual Studio Team Services work item tag",
-        "helpText": "Enter the tag you want to add to each Visual Studio Team Services linked work item. If empty, no tag will be added."
-      }
-    }
-  },
-  "buttons": {
-    "create": "Novo work item",
-    "link": "Vincular a um work item",
-    "notify": "Notificar"
-  },
-  "parts": {
-    "workItems": "Work items vinculados"
-  },
-  "admin": {
-    "title": "Administration",
-    "summary": "Summary",
-    "details": "Details",
-    "settingsSaved": "Your Visual Studio Team Services settings have been saved."
-  },
-  "login": {
-    "title": "Login",
-    "help": "Defina suas credenciais alternativas Visual Studio Team Services.",
-    "username": "Usuário",
-    "password": "Senha",
-    "button": "Login",
-    "errRequiredFields": "Os campos Usuário e Senha são obrigatórios"
-  },
-  "workItems": {
-    "unlink": "Desvincular este item de trabalho",
-    "showDetails": "Mostrar mais detalhes deste item de trabalho",
-    "noWorkItem": "Não há itens de trabalho vinculados a este ticket.",
-    "title": "Itens de trabalho vinculados: {{count}}"
-  },
-  "queryResults": {
-    "columnId": "Id",
-    "columnType": "Tipo",
-    "columnTitle": "Título",
-    "noWorkItem": "A consulta não retornou nenhum item de trabalho.",
-    "returnedWorkItems": "A consulta retornou {{count}} itens de trabalho"
-  },
-  "modals": {
-    "details": {
-      "title": "{{name}} detalhes",
-      "loading": "Carregando detalhes do item de trabalho...",
-      "close": "Fechar"
+    "app": {
+        "parameters": {
+            "vso_account": {
+                "label": "Visual Studio Team Services account name",
+                "helpText": "Enter your Visual Studio Team Services subdomain (part before visualstudio.com). Learn more by visiting http://go.microsoft.com/fwlink/?LinkID=396756"
+            },
+            "vso_tag": {
+                "label": "Visual Studio Team Services work item tag",
+                "helpText": "Enter the tag you want to add to each Visual Studio Team Services linked work item. If empty, no tag will be added."
+            }
+        }
     },
-    "unlink": {
-      "title": "Desvincular item de trabalho",
-      "text": "Você deseja desvincular o item <strong>{{name}}</strong> deste ticket?",
-      "close": "Não, não faça nada",
-      "accept": "Sim, desvincule o item de trabalho.",
-      "errUnlink": "Não foi possível desvincular o ticket no Visual Studio Team Services. Por favor, tente novamente."
+    "buttons": {
+        "create": "Novo work item",
+        "link": "Vincular a um work item",
+        "notify": "Notificar"
     },
-    "link": {
-      "title": "Vincular a um item de trabalho existente",
-      "close": "Voltar",
-      "accept": "Vincular",
-      "search": "Buscar",
-      "query": "Query",
-      "reloadQueries": "Recarregar lista de consulta",
-      "help": "Entre o ID do item de trablho que você gostaria de vincular a este ticket. Se você não souber o Id do item de trabalho para vincular, clique no botão 'Procurar' para pesquisar o item de trabalho correspondente.", 
-      "searchLegend": "Procurar",
-      "projectLabel": "Projeto",
-      "queryLabel": "Consulta",
-      "errWorkItemIdNaN": "O Id do item de trabalho deve ser um número.",
-      "errCannotGetWorkItem": "Um erro aconteceu enquanto pesquisava o item de trabalho. Por favor, tente novamente.", 
-      "errCannotUpdateWorkItem": "Algo aconteceu enquanto atualizava o item de trabalho. Por favor, tente novamente.", 
-      "errAlreadyLinked": "Este ticket já esta vinculado a este item de trabalho."
+    "parts": {
+        "workItems": "Work items vinculados"
     },
-    "new": {
-      "title": "Novo item de trabalho de desenvolvimento",
-      "close": "Voltar",
-      "accept": "Criar Item de Trabalho de Desenvolvimento",
-      "help": "Preencha este formulário para criar um novo item de trabalho para desenvolvimento, vinculado a este ticket.", 
-      "automatic": "Automatic",
-      "errProjRequired": "O projeto é obrigatório",
-      "errWorkItemTypeRequired": "O tipo de work item é obrigatório",
-      "errSummaryRequired": "O título é obrigatório",
-      "fields": {
-        "project": "Projeto",
-        "area": "Area",
-        "type": "Tipo",
-        "summary": "Título",
-        "description": "Descrição",
-        "assignee": "Assignee",
-        "requester": "Requester",
-        "attachments": "Anexos",
-        "severity": "Criticidade",
-        "DevelopmentDate": "Data de desenvolvimento"
-      },
-      "copyDescription": "Copiar descrição do Ticket"
+    "admin": {
+        "title": "Administration",
+        "summary": "Summary",
+        "details": "Details",
+        "settingsSaved": "Your Visual Studio Team Services settings have been saved."
+    },
+    "login": {
+        "title": "Login",
+        "help": "Defina suas credenciais alternativas Visual Studio Team Services.",
+        "username": "Usuário",
+        "password": "Senha",
+        "button": "Login",
+        "errRequiredFields": "Os campos Usuário e Senha são obrigatórios"
+    },
+    "workItems": {
+        "unlink": "Desvincular este item de trabalho",
+        "showDetails": "Mostrar mais detalhes deste item de trabalho",
+        "noWorkItem": "Não há itens de trabalho vinculados a este ticket.",
+        "title": "Itens de trabalho vinculados: {{count}}"
+    },
+    "queryResults": {
+        "columnId": "Id",
+        "columnType": "Tipo",
+        "columnTitle": "Título",
+        "noWorkItem": "A consulta não retornou nenhum item de trabalho.",
+        "returnedWorkItems": "A consulta retornou {{count}} itens de trabalho"
+    },
+    "modals": {
+        "details": {
+            "title": "{{name}} detalhes",
+            "loading": "Carregando detalhes do item de trabalho...",
+            "close": "Fechar"
+        },
+        "unlink": {
+            "title": "Desvincular item de trabalho",
+            "text": "Você deseja desvincular o item <strong>{{name}}</strong> deste ticket?",
+            "close": "Não, não faça nada",
+            "accept": "Sim, desvincule o item de trabalho.",
+            "errUnlink": "Não foi possível desvincular o ticket no Visual Studio Team Services. Por favor, tente novamente."
+        },
+        "link": {
+            "title": "Vincular a um item de trabalho existente",
+            "close": "Voltar",
+            "accept": "Vincular",
+            "search": "Buscar",
+            "query": "Query",
+            "reloadQueries": "Recarregar lista de consulta",
+            "help": "Entre o ID do item de trablho que você gostaria de vincular a este ticket. Se você não souber o Id do item de trabalho para vincular, clique no botão 'Procurar' para pesquisar o item de trabalho correspondente.",
+            "searchLegend": "Procurar",
+            "projectLabel": "Projeto",
+            "queryLabel": "Consulta",
+            "errWorkItemIdNaN": "O Id do item de trabalho deve ser um número.",
+            "errCannotGetWorkItem": "Um erro aconteceu enquanto pesquisava o item de trabalho. Por favor, tente novamente.",
+            "errCannotUpdateWorkItem": "Algo aconteceu enquanto atualizava o item de trabalho. Por favor, tente novamente.",
+            "errAlreadyLinked": "Este ticket já esta vinculado a este item de trabalho."
+        },
+        "new": {
+            "title": "Novo item de trabalho de desenvolvimento",
+            "close": "Voltar",
+            "accept": "Criar Item de Trabalho de Desenvolvimento",
+            "help": "Preencha este formulário para criar um novo item de trabalho para desenvolvimento, vinculado a este ticket.",
+            "automatic": "Automatic",
+            "errProjRequired": "O projeto é obrigatório",
+            "errWorkItemTypeRequired": "O tipo de work item é obrigatório",
+            "errSummaryRequired": "O título é obrigatório",
+            "fields": {
+                "project": "Projeto",
+                "area": "Area",
+                "type": "Tipo",
+                "summary": "Título",
+                "description": "Descrição",
+                "assignee": "Assignee",
+                "requester": "Requester",
+                "attachments": "Anexos",
+                "severity": "Criticidade",
+                "DevelopmentDate": "Data de desenvolvimento"
+            },
+            "copyDescription": "Copiar descrição do Ticket",
+            "severity": {
+                "critical": "Crítico",
+                "high": "Alto",
+                "medium": "Médio",
+                "low": "Baixo"
+            }
+        },
+        "notify": {
+            "title": "Novo comentário no item de trabalho",
+            "close": "Voltar",
+            "accept": "Comentar no item de trabalho",
+            "placeholder": "Digite o texto para comentar no item de trabalho",
+            "copyLastComment": "Copiar último comentário do Ticket",
+            "errCommentRequired": "O comentário é obrigatório"
+        }
     },
     "notify": {
-      "title": "Novo comentário no item de trabalho",
-      "close": "Voltar",
-      "accept": "Comentar no item de trabalho",
-      "placeholder": "Digite o texto para comentar no item de trabalho",
-      "copyLastComment": "Copiar último comentário do Ticket",
-      "errCommentRequired": "O comentário é obrigatório"
-    }
-  },
-  "notify": {
-    "message": "-- Esta notificação será enviada pelo Zendesk para todos os itens de trabalho do Visual Studio Team Services vinculados por {{name}}. --", 
-    "vso": "Comentário do item de trabalho de desenvolvimento {{workItemKey}}", 
-    "notification": "O item de trabalho de desenvolvimento vinculados a este ticket foram notificados",
-    "workItemCreated": "Item de trabalho de desenvolvimento criado com o id: %@", 
-    "workItemLinked": "Ticket vinculado com o item de trabalho de desenvolvimento com id: %@", 
-    "workItemUnlinked": "Ticket desvinculado com o item de trabalho de desenvolvimento com id: %@",
-    "credentialsSaved": "Salvo com sucesso"
-  },
-  "finishSetup": "Você não finalizou a configuração da aplicação: A conta do VSTS esta vazia.", 
-  "errorAjax": "Houve um erro na chamada ao servidor. Por favor, tente novamente", 
-  "errorServer": "[%@ %@: %@]",
-  "errorLoadingApp": "Algo errado aconteceu enquanto carregava a aplicação. Confirme que o login e senha estão corretas clicando no ícone do usuário.",
-  "errorInvalidAccount": "A conta do VSTS '{{accountName}}' não existe ou você não tem permissão de acessá-la. Contate o adminitrador do Zendesk para verificar e rever as configurações do aplicativo.",
-  "errorLoadingWorkItems": "Algo errado ao carregar os itens de trabalho. Clique no ícone Recarregar para tentar novamente",
-  "errorOoops": "Ooops!",
-  "errorReadingFieldSettings": "Houve um erro ao ler as configurações. Aplicando as configurações padrão"
+        "message": "-- Esta notificação será enviada pelo Zendesk para todos os itens de trabalho do Visual Studio Team Services vinculados por {{name}}. --",
+        "vso": "Comentário do item de trabalho de desenvolvimento {{workItemKey}}",
+        "notification": "O item de trabalho de desenvolvimento vinculados a este ticket foram notificados",
+        "workItemCreated": "Item de trabalho de desenvolvimento criado com o id: %@",
+        "workItemLinked": "Ticket vinculado com o item de trabalho de desenvolvimento com id: %@",
+        "workItemUnlinked": "Ticket desvinculado com o item de trabalho de desenvolvimento com id: %@",
+        "credentialsSaved": "Salvo com sucesso"
+    },
+    "finishSetup": "Você não finalizou a configuração da aplicação: A conta do VSTS esta vazia.",
+    "errorAjax": "Houve um erro na chamada ao servidor. Por favor, tente novamente",
+    "errorServer": "[%@ %@: %@]",
+    "errorLoadingApp": "Algo errado aconteceu enquanto carregava a aplicação. Confirme que o login e senha estão corretas clicando no ícone do usuário.",
+    "errorInvalidAccount": "A conta do VSTS '{{accountName}}' não existe ou você não tem permissão de acessá-la. Contate o adminitrador do Zendesk para verificar e rever as configurações do aplicativo.",
+    "errorLoadingWorkItems": "Algo errado ao carregar os itens de trabalho. Clique no ícone Recarregar para tentar novamente",
+    "errorOoops": "Ooops!",
+    "errorReadingFieldSettings": "Houve um erro ao ler as configurações. Aplicando as configurações padrão"
 }


### PR DESCRIPTION
Hello, bfcamara

First, sorry for doing just one PR for many features... 

I'm integrating Zendesk and VSTS in a client and they asked me to do a lot of customization. I think you'll like some of then:

* Fixed a bug in Severity field -> jquery selector was wrong, its searching by class of selector field, and need to search by #id.

* WorkItems whitelist as an app setting 

* Root Area path as an app setting (if you config as 'Project\Support' you will see only childs of 'Project\Support'. You won't be able to see 'Project\Product1' area path.). If you don't configure those setting, will be able to see all area paths

* Severity levels of bug work item as translation item

* PT-BR support

Tell me if you have some trouble with this PR.

Cheers,

Gerson Dias