### PR TITLE
Fix attachments not getting added as links when creating a new VSTS work item

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Visual Studio Team Services App for Zendesk
 
+![master build](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/6993/badge)
+
 > Get the [latest version](https://github.com/Microsoft/vsts-zendesk-app/releases) of the app
 
 Unite your customer support and development teams. Quickly create or link work items to tickets, enable efficient two-way communication, and stop using email to check status.
@@ -38,4 +40,3 @@ See [full instructions](https://www.visualstudio.com/docs/marketplace/integrate/
 4. Pick and the Visual Studio Team Services event which will post to Zendesk
 5. Tell Zendesk what to do when the event occurs
 6. Test the service hook subscription and finish the wizard
-

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -12,7 +12,7 @@
   "singleInstall": true,
   "private": true,
   "frameworkVersion": "2.0",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "parameters": [
     {
       "name": "vso_account",

--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
     "build": "webpack -p",
     "watch": "webpack --watch"
   },
-  "version": "0.6.0"
+  "version": "0.6.2"
 }

--- a/src/javascripts/app.js
+++ b/src/javascripts/app.js
@@ -1038,18 +1038,6 @@ const App = (function() {
                 return _.contains(VSO_WI_TYPES_WHITE_LISTS, wit.name);
             });
         },
-        buildPatchToAddWorkItemField: function(fieldName, value) {
-            // Check if the field type is html to replace newlines by br
-            if (this.isHtmlContentField(fieldName)) {
-                value = value.replace(/\n/g, "<br>");
-            }
-
-            return {
-                op: "add",
-                path: helpers.fmt("/fields/%@", fieldName),
-                value: value,
-            };
-        },
         isHtmlContentField: function(fieldName) {
             var field = this.getFieldByFieldRefName(fieldName);
 
@@ -1059,26 +1047,6 @@ const App = (function() {
             } else {
                 return false;
             }
-        },
-        buildPatchToAddWorkItemHyperlink: function(url, name, comment) {
-            return {
-                op: "add",
-                path: "/relations/-",
-                value: {
-                    rel: "Hyperlink",
-                    url: url,
-                    attributes: {
-                        name: name,
-                        comment: comment,
-                    },
-                },
-            };
-        },
-        buildPatchToRemoveWorkItemHyperlink: function(pos) {
-            return {
-                op: "remove",
-                path: helpers.fmt("/relations/%@", pos),
-            };
         },
         getAjaxErrorMessage: function(jqXHR, errMsg) {
             errMsg = errMsg || this.I18n.t("errorAjax"); //Let's try get a friendly message based on some cases
@@ -1093,36 +1061,6 @@ const App = (function() {
 
             var detail = this.I18n.t("errorServer").fmt(jqXHR.status, jqXHR.statusText, serverErrMsg);
             return errMsg + " " + detail;
-        },
-        buildPatchToAddWorkItemAttachments: async function(attachments) {
-            const _ticket7 = await wrapZafClient(this.zafClient, "ticket");
-
-            return _.map(
-                attachments,
-                async function(att) {
-                    return this.buildPatchToAddWorkItemHyperlink(
-                        att.url,
-                        VSO_ZENDESK_LINK_TO_TICKET_ATTACHMENT_PREFIX + _ticket7.id,
-                        att.name,
-                    );
-                }.bind(this),
-            );
-        },
-        getSelectedAttachments: function($modal) {
-            var attachments = [];
-            $modal.find(".attachments input").each(
-                function(ix, el) {
-                    var $el = this.$(el);
-
-                    if ($el.is(":checked")) {
-                        attachments.push({
-                            url: $el.val(),
-                            name: $el.data("fileName"),
-                        });
-                    }
-                }.bind(this),
-            );
-            return attachments;
         },
         buildAccountUrl: function() {
             var baseUrl;

--- a/src/javascripts/modal.js
+++ b/src/javascripts/modal.js
@@ -626,7 +626,6 @@ const ModalApp = BaseApp.extend({
         }
 
         const description = $modal.find(".description").val();
-        // var attachments = this.getSelectedAttachments($modal);
         let operations = [].concat(
             this.buildPatchToAddWorkItemField("System.Title", summary),
             this.buildPatchToAddWorkItemField("System.Description", description),
@@ -642,8 +641,9 @@ const ModalApp = BaseApp.extend({
 
         if (this.hasFieldDefined(workItemType, "Microsoft.VSTS.TCM.ReproSteps")) {
             operations.push(this.buildPatchToAddWorkItemField("Microsoft.VSTS.TCM.ReproSteps", description));
-        } //Set tag
-
+        } 
+        
+        //Set tag
         if (this.setting("vso_tag")) {
             operations.push(this.buildPatchToAddWorkItemField("System.Tags", this.setting("vso_tag")));
         }
@@ -654,7 +654,10 @@ const ModalApp = BaseApp.extend({
         );
 
         //Add hyperlinks to attachments
-        //operations = operations.concat(await this.buildPatchToAddWorkItemAttachments(attachments));
+        const attachments = this.getSelectedAttachments($modal);
+        if (attachments.length > 0) {
+            operations = operations.concat(this.buildPatchToAddWorkItemAttachments(attachments, ticket));
+        }
 
         try {
             const data = await this.execQueryOnSidebar(["ajax", "createVsoWorkItem", proj.id, workItemType.name, operations]);
@@ -787,6 +790,33 @@ const ModalApp = BaseApp.extend({
             },
         };
     },
+    buildPatchToAddWorkItemAttachments: function(attachments, ticket) {
+        return _.map(
+            attachments,
+            function(att) {
+                return this.buildPatchToAddWorkItemHyperlink(
+                    att.url,
+                    VSO_ZENDESK_LINK_TO_TICKET_ATTACHMENT_PREFIX + ticket.id,
+                    att.name,
+                );
+            }.bind(this),
+        );
+    },
+    getSelectedAttachments: function($modal) {
+        var attachments = [];
+        $modal.find(".attachments input").each(
+            function(ix, el) {
+                var $el = this.$(el);
+                if ($el.is(":checked")) {
+                    attachments.push({
+                        url: $el.val(),
+                        name: $el.attr("data-file-name"),
+                    });
+                }
+            }.bind(this),
+        );
+        return attachments;
+    },    
     buildPatchToRemoveWorkItemHyperlink: function(pos) {
         return {
             op: "remove",

--- a/src/templates/notify.hdbs
+++ b/src/templates/notify.hdbs
@@ -3,6 +3,7 @@
 </p>
 <textarea placeholder="{{t "modals.notify.placeholder"}}"></textarea>
 <a href="#" class="copyLastComment">{{t "modals.notify.copyLastComment"}}</a>
+<!-- Temporarily remove because there isn't support for adding/removing attachment links
 {{#if attachments.length}}
     <div>
       <label>{{t "modals.new.fields.attachments"}}</label>
@@ -11,7 +12,7 @@
           {{#each attachments}}
             <li>
               <label>
-                <input type='checkbox' value='{{content_url}}' data-file-name='{{file_name}}'>
+                <input type='checkbox' value='{{content_url}}' data-file-name='{{file_name}}' checked>
                 {{#if thumbnails.length}}
                   <img src="{{thumbnails.0.content_url}}">
                 {{/if}}
@@ -22,6 +23,6 @@
         </ul>
       </div>
     </div>
-{{/if}}
+{{/if}}-->
 </form>
 <div class="loading" style='display:none'>{{spinner "dotted"}}</div>


### PR DESCRIPTION
This addresses [part] of issue #48 (ticket attachment links not added to new work item). 

This does not address the issue with attachments not getting linked with the "notify" function. This apparently has been broken for awhile. Since this fix is not trivial, I temporarily removed the attachment checkboxes from the "notify" dialog to avoid confusion. 